### PR TITLE
Se quitan los api key/secret del SDK, se agrega el método setCredentials

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -268,7 +268,7 @@ class ClientBase extends Base {
                 const error = handleError(err, obj);
                 if (!_.isNil(error)) {
                     reject(error);
-                    callback(error, null);
+                    cb(error, null);
                 } else if (obj.data) {
                     const ObjFunc = this._stringToClass(model);
                     // resolve(new ObjFunc(this, obj.data));

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -8,19 +8,19 @@ const assign = require('object-assign');
 
 const Base = require('./Base');
 const {
-	BaseModel,
-	Order,
+    BaseModel,
+    Order,
 } = require('./model');
 const {
-	handleError,
-	handleHttpError,
+    handleError,
+    handleHttpError,
 } = require('./ErrorHandler');
 
 const BASE_URI = 'https://api.cryptomkt.com/v2/';
 
 const MODELS = {
-	base: BaseModel,
-	order: Order,
+    base: BaseModel,
+    order: Order,
 };
 
 //
@@ -32,247 +32,264 @@ const MODELS = {
 //   'baseApiUri'   : baseApiUri,
 // };
 
+let apiKey;
+let apiSecret;
+
 class ClientBase extends Base {
-	constructor(opts) {
-		super();
-		assign(this, {
-			baseApiUri: BASE_URI,
-			strictSSL: true,
-			timeout: 5000,
-		}, opts);
-		this.api = !!(this.apiKey && this.apiSecret);
+    constructor(opts) {
+        super();
 
-		if (!(this.api)) {
-			throw new Error('you must either provide the "apiKey" & "apiSecret" parameters');
-		}
-	}
+        this.setCredentials(opts.apiKey, opts.apiSecret);
+        this.api = !!(apiKey && apiSecret);
 
-	_generateSignature(path, bodyStr) {
-		let values = '';
-		const keys = [];
+        if (!(this.api)) {
+            throw new Error('you must either provide the "apiKey" & "apiSecret" parameters');
+        }
 
-		_.forIn(bodyStr, (value, key) => {
-			keys.push(key);
-		});
+        delete opts.apiKey;
+        delete opts.apiSecret;
+        assign(this, {
+            baseApiUri: BASE_URI,
+            strictSSL: true,
+            timeout: 5000,
+        }, opts);
+    }
 
-		keys.sort();
+    setCredentials(key, secret) {
+        if (!key || !secret) {
+            throw Error("Debes especificar los api key y secret");
+        }
 
-		for (let i = 0; i < keys.length; i += 1) {
-			values += bodyStr[keys[i]];
-		}
+        apiKey = key;
+        apiSecret = secret;
+    }
 
-		const timestamp = Math.floor(Date.now() / 1000);
-		const message = `${timestamp}/v2/${path}${values}`;
-		const signature = crypto.createHmac('sha384', this.apiSecret).update(message).digest('hex');
+    _generateSignature(path, bodyStr) {
+        let values = '';
+        const keys = [];
 
-		return {
-			digest: signature,
-			timestamp,
-		};
-	}
+        _.forIn(bodyStr, (value, key) => {
+            keys.push(key);
+        });
 
-	_generateReqOptions(method, url, path, params, headers) {
-		const parameters = params || {};
+        keys.sort();
 
-		// specify the options
-		const options = {
-			url: url + path,
-			strictSSL: this.strictSSL,
-			timeout: this.timeout,
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				Accept: 'application/json',
-				'User-Agent': 'cryptomkt/node/1.0.0',
-			},
-		};
+        for (let i = 0; i < keys.length; i += 1) {
+            values += bodyStr[keys[i]];
+        }
 
-		if (method === 'get') {
-			options.qs = parameters;
-		} else if (method === 'post') {
-			options.form = parameters;
-		}
+        const timestamp = Math.floor(Date.now() / 1000);
+        const message = `${timestamp}/v2/${path}${values}`;
+        const signature = crypto.createHmac('sha384', apiSecret).update(message).digest('hex');
 
-		options.headers = headers || {};
+        return {
+            digest: signature,
+            timestamp,
+        };
+    }
 
-		if (this.apiSecret && this.apiKey) {
-			let sig;
-			if (method === 'get') {
-				sig = this._generateSignature(path, {});
-			} else {
-				sig = this._generateSignature(path, params);
-			}
+    _generateReqOptions(method, url, path, params, headers) {
+        const parameters = params || {};
 
-			options.headers = assign(options.headers, {
-				'X-MKT-SIGNATURE': sig.digest,
-				'X-MKT-TIMESTAMP': sig.timestamp,
-				'X-MKT-APIKEY': this.apiKey,
-			});
-		}
+        // specify the options
+        const options = {
+            url: url + path,
+            strictSSL: this.strictSSL,
+            timeout: this.timeout,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Accept: 'application/json',
+                'User-Agent': 'cryptomkt/node/1.0.0',
+            },
+        };
 
-		return options;
-	}
+        if (method === 'get') {
+            options.qs = parameters;
+        } else if (method === 'post') {
+            options.form = parameters;
+        }
 
-	_newApiObject(client, obj, cls) {
-		let Cls = cls;
+        options.headers = headers || {};
 
-		if (obj instanceof Array) {
-			return obj.map((x) => this._newApiObject(client, x, Cls));
-		}
+        if (apiSecret && apiKey) {
+            let sig;
+            if (method === 'get') {
+                sig = this._generateSignature(path, {});
+            } else {
+                sig = this._generateSignature(path, params);
+            }
 
-		if (typeof obj === 'string') {
-			if (obj === 'null') return null;
-			return obj;
-		}
+            options.headers = assign(options.headers, {
+                'X-MKT-SIGNATURE': sig.digest,
+                'X-MKT-TIMESTAMP': sig.timestamp,
+                'X-MKT-APIKEY': apiKey,
+            });
+        }
 
-		if (obj === null) {
-			return obj;
-		}
+        return options;
+    }
 
-		if (typeof obj === 'number') {
-			return obj;
-		}
+    _newApiObject(client, obj, cls) {
+        let Cls = cls;
 
-		if (!Cls) {
-			Cls = BaseModel;
-		}
+        if (obj instanceof Array) {
+            return obj.map((x) => this._newApiObject(client, x, Cls));
+        }
 
-		const result = {};
-		const keys = _.keys(obj);
-		for (let i = 0; i < keys.length; i += 1) {
-			const key = keys[i];
-			if (obj.hasOwnProperty(key)) {
-				result[key] = this._newApiObject(client, obj[key]);
-			}
-		}
-		return new Cls(client, result);
-	}
+        if (typeof obj === 'string') {
+            if (obj === 'null') return null;
+            return obj;
+        }
 
-	_makeApiObject(response, model) {
-		const _response = {
-			response,
-		};
-		if (response.pagination) {
-			_response.pagination = response.pagination;
-		}
+        if (obj === null) {
+            return obj;
+        }
 
-		let obj;
+        if (typeof obj === 'number') {
+            return obj;
+        }
 
-		if (response.data instanceof Array) {
-			const ObjFunc = this._stringToClass('base');
-			obj = new ObjFunc(this, _response);
-			assign(obj, {
-				data: this._newApiObject(this, response.data, model),
-			});
-		} else {
-			obj = { data: this._newApiObject(this, response.data, model) };
-			assign(obj, _response);
-		}
+        if (!Cls) {
+            Cls = BaseModel;
+        }
 
-		return obj;
-	}
+        const result = {};
+        const keys = _.keys(obj);
+        for (let i = 0; i < keys.length; i += 1) {
+            const key = keys[i];
+            if (obj.hasOwnProperty(key)) {
+                result[key] = this._newApiObject(client, obj[key]);
+            }
+        }
+        return new Cls(client, result);
+    }
 
-	_getHttp(path, args, callback, headers) {
-		let params = {};
-		if (args && !_.isEmpty(args)) {
-			params = args;
-		}
+    _makeApiObject(response, model) {
+        const _response = {
+            response,
+        };
+        if (response.pagination) {
+            _response.pagination = response.pagination;
+        }
 
-		const url = this.baseApiUri;
-		const opts = this._generateReqOptions('get', url, path, params, headers);
+        let obj;
 
-		request.get(opts, (err, response, body) => {
-			const error = handleHttpError(err, response);
-			if (!_.isNil(error)) {
-				callback(error, null);
-			} else if (!body) {
-				callback(new Error('empty response'), null);
-			} else {
-				const obj = JSON.parse(body);
-				callback(null, obj);
-			}
-		});
-	}
+        if (response.data instanceof Array) {
+            const ObjFunc = this._stringToClass('base');
+            obj = new ObjFunc(this, _response);
+            assign(obj, {
+                data: this._newApiObject(this, response.data, model),
+            });
+        } else {
+            obj = { data: this._newApiObject(this, response.data, model) };
+            assign(obj, _response);
+        }
 
-	_postHttp(path, args, callback, headers) {
-		let params = {};
-		if (args && !_.isEmpty(args)) {
-			params = args;
-		}
+        return obj;
+    }
 
-		const url = this.baseApiUri;
+    _getHttp(path, args, callback, headers) {
+        let params = {};
+        if (args && !_.isEmpty(args)) {
+            params = args;
+        }
 
-		const options = this._generateReqOptions('post', url, path, params, headers);
+        const url = this.baseApiUri;
+        const opts = this._generateReqOptions('get', url, path, params, headers);
 
-		request.post(options, (err, response, body) => {
-			const error = handleHttpError(err, response);
-			if (!_.isNil(error)) {
-				callback(error, null);
-			} else if (!body) {
-				callback(new Error('empty response'), null);
-			} else {
-				const obj = JSON.parse(body);
-				callback(null, obj);
-			}
-		});
-	}
+        request.get(opts, (err, response, body) => {
+            const error = handleHttpError(err, response);
+            if (!_.isNil(error)) {
+                callback(error, null);
+            } else if (!body) {
+                callback(new Error('empty response'), null);
+            } else {
+                const obj = JSON.parse(body);
+                callback(null, obj);
+            }
+        });
+    }
 
-	/**
-	 * args = {
-	 * 	'path'   : path,
-	 * 	'params' : params,
-	 * }
-	 */
-	_getOneHttp(args, model, callback, headers) {
-		const cb = callback || function () {};
-		return new Promise((resolve, reject) => {
-			this._getHttp(args.path, args.params, (err, obj) => {
-				const error = handleError(err, obj);
-				if (!_.isNil(error)) {
-					reject(error);
-					cb(error, null);
-				} else if (obj.data) {
-					const ObjFunc = this._stringToClass(model);
-					resolve(this._makeApiObject(obj, ObjFunc));
-					// resolve(new ObjFunc(this, obj.data));
-					cb(null, this._makeApiObject(obj, ObjFunc));
-					// callback(null, new ObjFunc(this, obj.data));
-				} else {
-					resolve(obj);
-					cb(null, obj);
-				}
-			}, headers);
-		});
-	}
+    _postHttp(path, args, callback, headers) {
+        let params = {};
+        if (args && !_.isEmpty(args)) {
+            params = args;
+        }
 
-	_postOneHttp(args, model, callback, headers) {
-		const cb = callback || function () {};
-		return new Promise((resolve, reject) => {
-			this._postHttp(args.path, args.params, (err, obj) => {
-				const error = handleError(err, obj);
-				if (!_.isNil(error)) {
-					reject(error);
-					callback(error, null);
-				} else if (obj.data) {
-					const ObjFunc = this._stringToClass(model);
-					// resolve(new ObjFunc(this, obj.data));
-					// resolve(new ObjFunc(this, obj.data));
-					// callback(null, new ObjFunc(this, obj.data));
-					// cb(null, new ObjFunc(this, obj.data));
-					resolve(this._makeApiObject(obj, ObjFunc));
-					// resolve(new ObjFunc(this, obj.data));
-					cb(null, this._makeApiObject(obj, ObjFunc));
-					// callback(null, new ObjFunc(this, obj.data));
-				} else {
-					resolve(obj);
-					cb(null, obj);
-				}
-			}, headers);
-		});
-	}
+        const url = this.baseApiUri;
 
-	_stringToClass(name) {
-		return MODELS[name];
-	}
+        const options = this._generateReqOptions('post', url, path, params, headers);
+
+        request.post(options, (err, response, body) => {
+            const error = handleHttpError(err, response);
+            if (!_.isNil(error)) {
+                callback(error, null);
+            } else if (!body) {
+                callback(new Error('empty response'), null);
+            } else {
+                const obj = JSON.parse(body);
+                callback(null, obj);
+            }
+        });
+    }
+
+    /**
+     * args = {
+     * 	'path'   : path,
+     * 	'params' : params,
+     * }
+     */
+    _getOneHttp(args, model, callback, headers) {
+        const cb = callback || function() {};
+        return new Promise((resolve, reject) => {
+            this._getHttp(args.path, args.params, (err, obj) => {
+                const error = handleError(err, obj);
+                if (!_.isNil(error)) {
+                    reject(error);
+                    cb(error, null);
+                } else if (obj.data) {
+                    const ObjFunc = this._stringToClass(model);
+                    resolve(this._makeApiObject(obj, ObjFunc));
+                    // resolve(new ObjFunc(this, obj.data));
+                    cb(null, this._makeApiObject(obj, ObjFunc));
+                    // callback(null, new ObjFunc(this, obj.data));
+                } else {
+                    resolve(obj);
+                    cb(null, obj);
+                }
+            }, headers);
+        });
+    }
+
+    _postOneHttp(args, model, callback, headers) {
+        const cb = callback || function() {};
+        return new Promise((resolve, reject) => {
+            this._postHttp(args.path, args.params, (err, obj) => {
+                const error = handleError(err, obj);
+                if (!_.isNil(error)) {
+                    reject(error);
+                    callback(error, null);
+                } else if (obj.data) {
+                    const ObjFunc = this._stringToClass(model);
+                    // resolve(new ObjFunc(this, obj.data));
+                    // resolve(new ObjFunc(this, obj.data));
+                    // callback(null, new ObjFunc(this, obj.data));
+                    // cb(null, new ObjFunc(this, obj.data));
+                    resolve(this._makeApiObject(obj, ObjFunc));
+                    // resolve(new ObjFunc(this, obj.data));
+                    cb(null, this._makeApiObject(obj, ObjFunc));
+                    // callback(null, new ObjFunc(this, obj.data));
+                } else {
+                    resolve(obj);
+                    cb(null, obj);
+                }
+            }, headers);
+        });
+    }
+
+    _stringToClass(name) {
+        return MODELS[name];
+    }
 }
 
 module.exports = ClientBase;


### PR DESCRIPTION
Cuando se imprime en consola la instancia del SDK, se imprimen los api key/secret configurados, siendo inseguro sobre todo al haber excepciones. Para evitar esto se saca esas variables fuera de la clase, en el mismo scope pero sin exportar, por lo tanto no debería ser posible acceder a ellos desde fuera.

Además se agrega el método setCredentials para poder utilizar múltiples api keys según la request a usar.