### PR TITLE
Se quitan los api key/secret del SDK, se agrega el método setCredentials

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -268,7 +268,7 @@ class ClientBase extends Base {
                 const error = handleError(err, obj);
                 if (!_.isNil(error)) {
                     reject(error);
-                    callback(error, null);
+                    cb(error, null);
                 } else if (obj.data) {
                     const ObjFunc = this._stringToClass(model);
                     // resolve(new ObjFunc(this, obj.data));

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -8,19 +8,19 @@ const assign = require('object-assign');
 
 const Base = require('./Base');
 const {
-	BaseModel,
-	Order,
+    BaseModel,
+    Order,
 } = require('./model');
 const {
-	handleError,
-	handleHttpError,
+    handleError,
+    handleHttpError,
 } = require('./ErrorHandler');
 
 const BASE_URI = 'https://api.cryptomkt.com/v2/';
 
 const MODELS = {
-	base: BaseModel,
-	order: Order,
+    base: BaseModel,
+    order: Order,
 };
 
 //
@@ -32,247 +32,264 @@ const MODELS = {
 //   'baseApiUri'   : baseApiUri,
 // };
 
+let apiKey;
+let apiSecret;
+
 class ClientBase extends Base {
-	constructor(opts) {
-		super();
-		assign(this, {
-			baseApiUri: BASE_URI,
-			strictSSL: true,
-			timeout: 5000,
-		}, opts);
-		this.api = !!(this.apiKey && this.apiSecret);
+    constructor(opts) {
+        super();
 
-		if (!(this.api)) {
-			throw new Error('you must either provide the "apiKey" & "apiSecret" parameters');
-		}
-	}
+        this.setCredentials(opts.apiKey, opts.apiSecret);
+        this.api = !!(apiKey && apiSecret);
 
-	_generateSignature(path, bodyStr) {
-		let values = '';
-		const keys = [];
+        if (!(this.api)) {
+            throw new Error('you must either provide the "apiKey" & "apiSecret" parameters');
+        }
 
-		_.forIn(bodyStr, (value, key) => {
-			keys.push(key);
-		});
+        delete opts.apiKey;
+        delete opts.apiSecret;
+        assign(this, {
+            baseApiUri: BASE_URI,
+            strictSSL: true,
+            timeout: 5000,
+        }, opts);
+    }
 
-		keys.sort();
+    setCredentials(key, secret) {
+        if (!key || !secret) {
+            throw Error("Debes especificar los api key y secret");
+        }
 
-		for (let i = 0; i < keys.length; i += 1) {
-			values += bodyStr[keys[i]];
-		}
+        apiKey = key;
+        apiSecret = secret;
+    }
 
-		const timestamp = Math.floor(Date.now() / 1000);
-		const message = `${timestamp}/v2/${path}${values}`;
-		const signature = crypto.createHmac('sha384', this.apiSecret).update(message).digest('hex');
+    _generateSignature(path, bodyStr) {
+        let values = '';
+        const keys = [];
 
-		return {
-			digest: signature,
-			timestamp,
-		};
-	}
+        _.forIn(bodyStr, (value, key) => {
+            keys.push(key);
+        });
 
-	_generateReqOptions(method, url, path, params, headers) {
-		const parameters = params || {};
+        keys.sort();
 
-		// specify the options
-		const options = {
-			url: url + path,
-			strictSSL: this.strictSSL,
-			timeout: this.timeout,
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				Accept: 'application/json',
-				'User-Agent': 'cryptomkt/node/1.0.0',
-			},
-		};
+        for (let i = 0; i < keys.length; i += 1) {
+            values += bodyStr[keys[i]];
+        }
 
-		if (method === 'get') {
-			options.qs = parameters;
-		} else if (method === 'post') {
-			options.form = parameters;
-		}
+        const timestamp = Math.floor(Date.now() / 1000);
+        const message = `${timestamp}/v2/${path}${values}`;
+        const signature = crypto.createHmac('sha384', apiSecret).update(message).digest('hex');
 
-		options.headers = headers || {};
+        return {
+            digest: signature,
+            timestamp,
+        };
+    }
 
-		if (this.apiSecret && this.apiKey) {
-			let sig;
-			if (method === 'get') {
-				sig = this._generateSignature(path, {});
-			} else {
-				sig = this._generateSignature(path, params);
-			}
+    _generateReqOptions(method, url, path, params, headers) {
+        const parameters = params || {};
 
-			options.headers = assign(options.headers, {
-				'X-MKT-SIGNATURE': sig.digest,
-				'X-MKT-TIMESTAMP': sig.timestamp,
-				'X-MKT-APIKEY': this.apiKey,
-			});
-		}
+        // specify the options
+        const options = {
+            url: url + path,
+            strictSSL: this.strictSSL,
+            timeout: this.timeout,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Accept: 'application/json',
+                'User-Agent': 'cryptomkt/node/1.0.0',
+            },
+        };
 
-		return options;
-	}
+        if (method === 'get') {
+            options.qs = parameters;
+        } else if (method === 'post') {
+            options.form = parameters;
+        }
 
-	_newApiObject(client, obj, cls) {
-		let Cls = cls;
+        options.headers = headers || {};
 
-		if (obj instanceof Array) {
-			return obj.map((x) => this._newApiObject(client, x, Cls));
-		}
+        if (apiSecret && apiKey) {
+            let sig;
+            if (method === 'get') {
+                sig = this._generateSignature(path, {});
+            } else {
+                sig = this._generateSignature(path, params);
+            }
 
-		if (typeof obj === 'string') {
-			if (obj === 'null') return null;
-			return obj;
-		}
+            options.headers = assign(options.headers, {
+                'X-MKT-SIGNATURE': sig.digest,
+                'X-MKT-TIMESTAMP': sig.timestamp,
+                'X-MKT-APIKEY': apiKey,
+            });
+        }
 
-		if (obj === null) {
-			return obj;
-		}
+        return options;
+    }
 
-		if (typeof obj === 'number') {
-			return obj;
-		}
+    _newApiObject(client, obj, cls) {
+        let Cls = cls;
 
-		if (!Cls) {
-			Cls = BaseModel;
-		}
+        if (obj instanceof Array) {
+            return obj.map((x) => this._newApiObject(client, x, Cls));
+        }
 
-		const result = {};
-		const keys = _.keys(obj);
-		for (let i = 0; i < keys.length; i += 1) {
-			const key = keys[i];
-			if (obj.hasOwnProperty(key)) {
-				result[key] = this._newApiObject(client, obj[key]);
-			}
-		}
-		return new Cls(client, result);
-	}
+        if (typeof obj === 'string') {
+            if (obj === 'null') return null;
+            return obj;
+        }
 
-	_makeApiObject(response, model) {
-		const _response = {
-			response,
-		};
-		if (response.pagination) {
-			_response.pagination = response.pagination;
-		}
+        if (obj === null) {
+            return obj;
+        }
 
-		let obj;
+        if (typeof obj === 'number') {
+            return obj;
+        }
 
-		if (response.data instanceof Array) {
-			const ObjFunc = this._stringToClass('base');
-			obj = new ObjFunc(this, _response);
-			assign(obj, {
-				data: this._newApiObject(this, response.data, model),
-			});
-		} else {
-			obj = { data: this._newApiObject(this, response.data, model) };
-			assign(obj, _response);
-		}
+        if (!Cls) {
+            Cls = BaseModel;
+        }
 
-		return obj;
-	}
+        const result = {};
+        const keys = _.keys(obj);
+        for (let i = 0; i < keys.length; i += 1) {
+            const key = keys[i];
+            if (obj.hasOwnProperty(key)) {
+                result[key] = this._newApiObject(client, obj[key]);
+            }
+        }
+        return new Cls(client, result);
+    }
 
-	_getHttp(path, args, callback, headers) {
-		let params = {};
-		if (args && !_.isEmpty(args)) {
-			params = args;
-		}
+    _makeApiObject(response, model) {
+        const _response = {
+            response,
+        };
+        if (response.pagination) {
+            _response.pagination = response.pagination;
+        }
 
-		const url = this.baseApiUri;
-		const opts = this._generateReqOptions('get', url, path, params, headers);
+        let obj;
 
-		request.get(opts, (err, response, body) => {
-			const error = handleHttpError(err, response);
-			if (!_.isNil(error)) {
-				callback(error, null);
-			} else if (!body) {
-				callback(new Error('empty response'), null);
-			} else {
-				const obj = JSON.parse(body);
-				callback(null, obj);
-			}
-		});
-	}
+        if (response.data instanceof Array) {
+            const ObjFunc = this._stringToClass('base');
+            obj = new ObjFunc(this, _response);
+            assign(obj, {
+                data: this._newApiObject(this, response.data, model),
+            });
+        } else {
+            obj = { data: this._newApiObject(this, response.data, model) };
+            assign(obj, _response);
+        }
 
-	_postHttp(path, args, callback, headers) {
-		let params = {};
-		if (args && !_.isEmpty(args)) {
-			params = args;
-		}
+        return obj;
+    }
 
-		const url = this.baseApiUri;
+    _getHttp(path, args, callback, headers) {
+        let params = {};
+        if (args && !_.isEmpty(args)) {
+            params = args;
+        }
 
-		const options = this._generateReqOptions('post', url, path, params, headers);
+        const url = this.baseApiUri;
+        const opts = this._generateReqOptions('get', url, path, params, headers);
 
-		request.post(options, (err, response, body) => {
-			const error = handleHttpError(err, response);
-			if (!_.isNil(error)) {
-				callback(error, null);
-			} else if (!body) {
-				callback(new Error('empty response'), null);
-			} else {
-				const obj = JSON.parse(body);
-				callback(null, obj);
-			}
-		});
-	}
+        request.get(opts, (err, response, body) => {
+            const error = handleHttpError(err, response);
+            if (!_.isNil(error)) {
+                callback(error, null);
+            } else if (!body) {
+                callback(new Error('empty response'), null);
+            } else {
+                const obj = JSON.parse(body);
+                callback(null, obj);
+            }
+        });
+    }
 
-	/**
-	 * args = {
-	 * 	'path'   : path,
-	 * 	'params' : params,
-	 * }
-	 */
-	_getOneHttp(args, model, callback, headers) {
-		const cb = callback || function () {};
-		return new Promise((resolve, reject) => {
-			this._getHttp(args.path, args.params, (err, obj) => {
-				const error = handleError(err, obj);
-				if (!_.isNil(error)) {
-					reject(error);
-					cb(error, null);
-				} else if (obj.data) {
-					const ObjFunc = this._stringToClass(model);
-					resolve(this._makeApiObject(obj, ObjFunc));
-					// resolve(new ObjFunc(this, obj.data));
-					cb(null, this._makeApiObject(obj, ObjFunc));
-					// callback(null, new ObjFunc(this, obj.data));
-				} else {
-					resolve(obj);
-					cb(null, obj);
-				}
-			}, headers);
-		});
-	}
+    _postHttp(path, args, callback, headers) {
+        let params = {};
+        if (args && !_.isEmpty(args)) {
+            params = args;
+        }
 
-	_postOneHttp(args, model, callback, headers) {
-		const cb = callback || function () {};
-		return new Promise((resolve, reject) => {
-			this._postHttp(args.path, args.params, (err, obj) => {
-				const error = handleError(err, obj);
-				if (!_.isNil(error)) {
-					reject(error);
-					callback(error, null);
-				} else if (obj.data) {
-					const ObjFunc = this._stringToClass(model);
-					// resolve(new ObjFunc(this, obj.data));
-					// resolve(new ObjFunc(this, obj.data));
-					// callback(null, new ObjFunc(this, obj.data));
-					// cb(null, new ObjFunc(this, obj.data));
-					resolve(this._makeApiObject(obj, ObjFunc));
-					// resolve(new ObjFunc(this, obj.data));
-					cb(null, this._makeApiObject(obj, ObjFunc));
-					// callback(null, new ObjFunc(this, obj.data));
-				} else {
-					resolve(obj);
-					cb(null, obj);
-				}
-			}, headers);
-		});
-	}
+        const url = this.baseApiUri;
 
-	_stringToClass(name) {
-		return MODELS[name];
-	}
+        const options = this._generateReqOptions('post', url, path, params, headers);
+
+        request.post(options, (err, response, body) => {
+            const error = handleHttpError(err, response);
+            if (!_.isNil(error)) {
+                callback(error, null);
+            } else if (!body) {
+                callback(new Error('empty response'), null);
+            } else {
+                const obj = JSON.parse(body);
+                callback(null, obj);
+            }
+        });
+    }
+
+    /**
+     * args = {
+     * 	'path'   : path,
+     * 	'params' : params,
+     * }
+     */
+    _getOneHttp(args, model, callback, headers) {
+        const cb = callback || function() {};
+        return new Promise((resolve, reject) => {
+            this._getHttp(args.path, args.params, (err, obj) => {
+                const error = handleError(err, obj);
+                if (!_.isNil(error)) {
+                    reject(error);
+                    cb(error, null);
+                } else if (obj.data) {
+                    const ObjFunc = this._stringToClass(model);
+                    resolve(this._makeApiObject(obj, ObjFunc));
+                    // resolve(new ObjFunc(this, obj.data));
+                    cb(null, this._makeApiObject(obj, ObjFunc));
+                    // callback(null, new ObjFunc(this, obj.data));
+                } else {
+                    resolve(obj);
+                    cb(null, obj);
+                }
+            }, headers);
+        });
+    }
+
+    _postOneHttp(args, model, callback, headers) {
+        const cb = callback || function() {};
+        return new Promise((resolve, reject) => {
+            this._postHttp(args.path, args.params, (err, obj) => {
+                const error = handleError(err, obj);
+                if (!_.isNil(error)) {
+                    reject(error);
+                    callback(error, null);
+                } else if (obj.data) {
+                    const ObjFunc = this._stringToClass(model);
+                    // resolve(new ObjFunc(this, obj.data));
+                    // resolve(new ObjFunc(this, obj.data));
+                    // callback(null, new ObjFunc(this, obj.data));
+                    // cb(null, new ObjFunc(this, obj.data));
+                    resolve(this._makeApiObject(obj, ObjFunc));
+                    // resolve(new ObjFunc(this, obj.data));
+                    cb(null, this._makeApiObject(obj, ObjFunc));
+                    // callback(null, new ObjFunc(this, obj.data));
+                } else {
+                    resolve(obj);
+                    cb(null, obj);
+                }
+            }, headers);
+        });
+    }
+
+    _stringToClass(name) {
+        return MODELS[name];
+    }
 }
 
 module.exports = ClientBase;

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -8,483 +8,486 @@ const EventBus = require('js-event-bus');
 const _ = require('lodash');
 
 class Socket {
-	constructor(client) {
-		this.client = client;
-		this.eventBus = new EventBus();
-		this.urlWorker = 'https://worker.cryptomkt.com';
-		this.socket = null;
-		this.debugging = true;
-		this.currenciesData = null;
-		this.balancesData = null;
-		this.operatedData = null;
-		this.openOrdersData = null;
-		this.historicalOrdersData = null;
-		this.openBookData = {};
-		this.historicalBookData = {};
-		this.candlesData = {};
-		this.boardData = {};
-		this.transports = ['websocket', 'polling'];
-	}
-
-	_deepClone(data) {
-		return _.cloneDeep(data);
-	}
-
-	_authSocket() {
-		this.client._getAuthSocket()
-			.then((obj) => {
-				this.socketClient.emit('user-auth', {
-					uid: obj.data.uid,
-					socid: obj.data.socid,
-				});
-			}).catch(() => {});
-	}
-
-	_reconnect() {
-		this.socketClient = socket(this.urlWorker, {
-			forceNew: false,
-			reconnectionAttempts: 1,
-			reconnectionDelay: 1000,
-			reconnectionDelayMax: 15000,
-			transports: this.transports,
-		});
-	}
-
-	_setupGeneralEvents() {
-		// Fired upon a successful reconnection.
-		this.socketClient.on('reconnect', () => {});
-
-		// Fired upon an attempt to reconnect.
-		this.socketClient.on('reconnect_attempt', () => {});
-
-		// Fired upon an attempt to reconnect.
-		this.socketClient.on('reconnecting', () => {});
-
-		// Fired when couldn’t reconnect within reconnectionAttempts.
-		this.socketClient.on('reconnect_failed', () => {
-			setTimeout(() => {
-				this._reconnect();
-			}, 5000 + _.random(0, 5000));
-		});
-
-
-		// Fired upon a disconnection.
-		this.socketClient.on('disconnect', (reason) => {
-			// the disconnection was initiated by the server, you need to reconnect manually
-			// else the socket will automatically try to reconnect
-			if (reason === 'io server disconnect' || reason === 'io client disconnect') {
-				setTimeout(() => {
-					this._reconnect();
-				}, 5000 + _.random(0, 5000));
-			}
-		});
-	}
-
-	_setupWorkerEvents() {
-		// EVENTS
-		// =============================================================================================
-
-		// CURRENCIES
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('currencies', (data) => {
-			this.currenciesData = data;
-		});
-
-		this.socketClient.on('currencies-delta', (deltas) => {
-			_.forEach(deltas, (delta) => {
-				if (this.currenciesData.to_tx !== delta.from_tx) {
-					this.socketClient.emit('currencies');
-					return false;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.currenciesData.data = jsondiffpatch.patch(this.currenciesData.data, deltaData);
-				this.currenciesData.to_tx = delta.to_tx;
-			});
-		});
-
-		// BALANCES
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('balance', (data) => {
-			_.forIn(data.data, (value) => {
-				const currency = _.filter(this.currenciesData.data, {
-					name: value.currency,
-				})[0];
-				value.currency_kind = currency.kind;
-				value.currency_name = currency.name;
-				value.currency_big_name = currency.big_name;
-				value.currency_prefix = currency.prefix;
-				value.currency_postfix = currency.postfix;
-				value.currency_decimals = currency.decimals;
-			});
-			this.balancesData = data;
-			this.eventBus.emit('balance', null, this._deepClone(this.balancesData.data));
-		});
-
-		this.socketClient.on('balance-delta', (deltas) => {
-			_.forEach(deltas, (delta, index, collection) => {
-				if (this.balancesData.to_tx !== delta.from_tx) {
-					this.socketClient.emit('balance');
-					return false;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.balancesData.data = jsondiffpatch.patch(this.balancesData.data, deltaData);
-				this.balancesData.to_tx = delta.to_tx;
-				if (index === collection.length - 1) {
-					_.forIn(this.balancesData.data, (value) => {
-						const currency = _.filter(this.currenciesData.data, {
-							name: value.currency,
-						})[0];
-						value.currency_kind = currency.kind;
-						value.currency_name = currency.name;
-						value.currency_big_name = currency.big_name;
-						value.currency_prefix = currency.prefix;
-						value.currency_postfix = currency.postfix;
-						value.currency_decimals = currency.decimals;
-					});
-
-					this.eventBus.emit('balance', null, this._deepClone(this.balancesData.data));
-				}
-			});
-		});
-
-		// OPEN-ORDERS
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('open-orders', (data) => {
-			this.openOrdersData = data;
-			this.eventBus.emit('open-orders', null, this._deepClone(data.data));
-		});
-
-		this.socketClient.on('open-orders-delta', (deltas) => {
-			_.forEach(deltas, (delta, index, collection) => {
-				if (this.openOrdersData.to_tx !== delta.from_tx) {
-					this.socketClient.emit('open-orders');
-					return false;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.openOrdersData.data = jsondiffpatch.patch(this.openOrdersData.data, deltaData);
-				this.openOrdersData.to_tx = delta.to_tx;
-				if (index === collection.length - 1) {
-					this.eventBus.emit('open-orders', null, this._deepClone(this.openOrdersData.data));
-				}
-			});
-		});
-
-		// HISTORICAL-ORDERS
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('historical-orders', (data) => {
-			this.historicalOrdersData = data;
-			this.eventBus.emit('historical-orders', null, this._deepClone(data.data));
-		});
-
-		this.socketClient.on('historical-orders-delta', (deltas) => {
-			_.forEach(deltas, (delta, index, collection) => {
-				if (this.historicalOrdersData.to_tx !== delta.from_tx) {
-					this.socketClient.emit('historical-orders');
-					return false;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.historicalOrdersData.data = jsondiffpatch.patch(
-					this.historicalOrdersData.data,
-					deltaData,
-				);
-				this.historicalOrdersData.to_tx = delta.to_tx;
-				if (index === collection.length - 1) {
-					this.eventBus.emit('historical-orders', null, this._deepClone(this.historicalOrdersData.data));
-				}
-			});
-		});
-
-		// OPERATED
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('operated', (data) => {
-			this.operatedData = data;
-			this.eventBus.emit('operated', null, this._deepClone(this.operatedData.data));
-		});
-
-		this.socketClient.on('operated-delta', (deltas) => {
-			_.forEach(deltas, (delta, index, collection) => {
-				if (this.operatedData.to_tx !== delta.from_tx) {
-					this.socketClient.emit('operated');
-					return false;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.operatedData.data = jsondiffpatch.patch(this.operatedData.data, deltaData);
-				this.operatedData.to_tx = delta.to_tx;
-				if (index === collection.length - 1) {
-					this.eventBus.emit('operated', null, this._deepClone(this.operatedData.data));
-				}
-			});
-		});
-
-		// OPEN-BOOK
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('open-book', (data) => {
-			this.openBookData[data.stock_id] = data;
-
-			const clean = {};
-			clean[data.stock_id] = {
-				sell: data.data[2],
-				buy: data.data[1],
-			};
-
-			this.eventBus.emit('open-book', null, this._deepClone(clean));
-		});
-
-		this.socketClient.on('open-book-delta', (delta) => {
-			const stockId = delta.stock_id;
-			if (_.has(this.openBookData, stockId)) {
-				if (this.openBookData[stockId].to_tx !== delta.from_tx) {
-					this.socketClient.emit('open-book', {
-						stockId,
-					});
-					return;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.openBookData[stockId].data = jsondiffpatch.patch(
-					this.openBookData[stockId].data,
-					deltaData,
-				);
-				this.openBookData[stockId].to_tx = delta.to_tx;
-
-				const clean = {};
-				clean[stockId] = {
-					sell: this.openBookData[stockId].data[2],
-					buy: this.openBookData[stockId].data[1],
-				};
-
-				this.eventBus.emit('open-book', null, this._deepClone(clean));
-			} else {
-				this.socketClient.emit('open-book', {
-					stockId: delta.stock_id,
-				});
-			}
-		});
-
-		// HISTORICAL-BOOK
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('historical-book', (data) => {
-			const stockId = data.stock_id;
-
-			this.historicalBookData[stockId] = data;
-
-			const result = {};
-			result[stockId] = this.historicalBookData[stockId].data;
-
-			this.eventBus.emit('historical-book', null, this._deepClone(result));
-		});
-
-		this.socketClient.on('historical-book-delta', (delta) => {
-			const stockId = delta.stock_id;
-			if (_.has(this.historicalBookData, stockId)) {
-				if (this.historicalBookData[stockId].to_tx !== delta.from_tx) {
-					this.socketClient.emit('historical-book', {
-						stockId,
-					});
-					return;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.historicalBookData[stockId].data = jsondiffpatch.patch(
-					this.historicalBookData[stockId].data,
-					deltaData,
-				);
-				this.historicalBookData[stockId].to_tx = delta.to_tx;
-
-				const result = {};
-				result[stockId] = this.historicalBookData[stockId].data;
-
-				this.eventBus.emit('historical-book', null, this._deepClone(result));
-			} else {
-				this.socketClient.emit('historical-book', {
-					stockId: delta.stock_id,
-				});
-			}
-		});
-
-		// CANDLES
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('candles', (data) => {
-			const stockId = data.stock_id;
-			this.candlesData[stockId] = data;
-
-			const result = {};
-			result[stockId] = this.candlesData[stockId].data;
-
-			const cloneResult = this._deepClone(result);
-
-			const cleanResult = _.mapValues(cloneResult, (obj) => {
-				if (_.has(obj, '1')) {
-					obj.buy = obj['1'];
-					delete obj['1'];
-				}
-
-				if (_.has(obj, '2')) {
-					obj.sell = obj['2'];
-					delete obj['2'];
-				}
-
-				return obj;
-			});
-
-			this.eventBus.emit('candles', null, cleanResult);
-		});
-
-		this.socketClient.on('candles-delta', (delta) => {
-			const stockId = delta.stock_id;
-			if (_.has(this.candlesData, stockId)) {
-				if (this.candlesData[stockId].to_tx !== delta.from_tx) {
-					this.socketClient.emit('candles', {
-						stockId,
-					});
-					return;
-				}
-
-				let deltaData = delta.delta_data;
-				if (_.isString(deltaData)) {
-					deltaData = JSON.parse(deltaData);
-				}
-
-				this.candlesData[stockId].data = jsondiffpatch.patch(
-					this.candlesData[stockId].data,
-					deltaData,
-				);
-				this.candlesData[stockId].to_tx = delta.to_tx;
-
-				const result = {};
-				result[stockId] = this.candlesData[stockId].data;
-
-				const cloneResult = this._deepClone(result);
-
-				const cleanResult = _.mapValues(cloneResult, (obj) => {
-					if (_.has(obj, '1')) {
-						obj.buy = obj['1'];
-						delete obj['1'];
-					}
-
-					if (_.has(obj, '2')) {
-						obj.sell = obj['2'];
-						delete obj['2'];
-					}
-
-					return obj;
-				});
-
-				this.eventBus.emit('candles', null, cleanResult);
-			} else {
-				this.socketClient.emit('candles', {
-					stockId: delta.stock_id,
-				});
-			}
-		});
-
-		// BOARD
-		// ---------------------------------------------------------------------------------------------
-		this.socketClient.on('board', (data) => {
-			this.boardData = data;
-			this.eventBus.emit('ticker', null, this._deepClone(this.boardData.data));
-		});
-
-		this.socketClient.on('board-delta', (delta) => {
-			if (this.boardData.to_tx !== delta.from_tx) {
-				this.socketClient.emit('board');
-				return false;
-			}
-
-			let deltaData = delta.delta_data;
-			if (_.isString(deltaData)) {
-				deltaData = JSON.parse(deltaData);
-			}
-
-			this.boardData.data = jsondiffpatch.patch(this.boardData.data, deltaData);
-			this.boardData.to_tx = delta.to_tx;
-
-			this.eventBus.emit('ticker', null, this._deepClone(this.boardData.data));
-		});
-	}
-
-	connect(...transports) {
-		if (!_.isEmpty(transports)) {
-			this.transports = transports.filter(
-				(transport) => transport === 'polling' || transport === 'websocket',
-			);
-			if (_.isEmpty(this.transports)) {
-				return Promise.reject(new Error('Invalid transports'));
-			}
-		}
-		this.socketClient = socket(this.urlWorker, {
-			forceNew: false,
-			reconnectionAttempts: 1,
-			reconnectionDelay: 1000,
-			reconnectionDelayMax: 15000,
-			transports: this.transports,
-		});
-
-		this._setupGeneralEvents();
-		this._setupWorkerEvents();
-
-		return new Promise((resolve, reject) => {
-			// Fired upon a connection including a successful reconnection.
-			this.socketClient.on('connect', () => {
-				this._authSocket();
-				resolve(this);
-			});
-
-			// Fired upon a connection error.
-			this.socketClient.on('connect_error', (error) => {
-				reject(new Error(error));
-			});
-		});
-	}
-
-	on(event, callback) {
-		this.eventBus.on(event, callback);
-	}
-
-	subscribe(...pairs) {
-		_.forEach(pairs, (pair) => {
-			this.socketClient.emit('subscribe', pair);
-		});
-	}
-
-	unsubscribe(...pairs) {
-		_.forEach(pairs, (pair) => {
-			this.socketClient.emit('unsubscribe', pair);
-		});
-	}
+    constructor(client) {
+        this.client = client;
+        this.eventBus = new EventBus();
+        this.urlWorker = 'https://worker.cryptomkt.com';
+        this.socket = null;
+        this.debugging = true;
+        this.currenciesData = null;
+        this.balancesData = null;
+        this.operatedData = null;
+        this.openOrdersData = null;
+        this.historicalOrdersData = null;
+        this.openBookData = {};
+        this.historicalBookData = {};
+        this.candlesData = {};
+        this.boardData = {};
+        this.transports = ['websocket', 'polling'];
+    }
+
+    _deepClone(data) {
+        return _.cloneDeep(data);
+    }
+
+    _authSocket() {
+        this.client._getAuthSocket()
+            .then((obj) => {
+                this.socketClient.emit('user-auth', {
+                    uid: obj.data.uid,
+                    socid: obj.data.socid,
+                });
+            }).catch(() => {});
+    }
+
+    _reconnect() {
+        this.socketClient = socket(this.urlWorker, {
+            forceNew: false,
+            reconnectionAttempts: 1,
+            reconnectionDelay: 1000,
+            reconnectionDelayMax: 15000,
+            transports: this.transports,
+        });
+    }
+
+    _setupGeneralEvents() {
+        // Fired upon a successful reconnection.
+        this.socketClient.on('reconnect', () => {});
+
+        // Fired upon an attempt to reconnect.
+        this.socketClient.on('reconnect_attempt', () => {});
+
+        // Fired upon an attempt to reconnect.
+        this.socketClient.on('reconnecting', () => {});
+
+        // Fired when couldn’t reconnect within reconnectionAttempts.
+        this.socketClient.on('reconnect_failed', () => {
+            setTimeout(() => {
+                this._reconnect();
+            }, 5000 + _.random(0, 5000));
+        });
+
+
+        // Fired upon a disconnection.
+        this.socketClient.on('disconnect', (reason) => {
+            // the disconnection was initiated by the server, you need to reconnect manually
+            // else the socket will automatically try to reconnect
+            if (reason === 'io server disconnect' || reason === 'io client disconnect') {
+                setTimeout(() => {
+                    this._reconnect();
+                }, 5000 + _.random(0, 5000));
+            }
+
+            this.eventBus.emit('disconnect');
+        });
+    }
+
+    _setupWorkerEvents() {
+        // EVENTS
+        // =============================================================================================
+
+        // CURRENCIES
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('currencies', (data) => {
+            this.currenciesData = data;
+        });
+
+        this.socketClient.on('currencies-delta', (deltas) => {
+            _.forEach(deltas, (delta) => {
+                if (this.currenciesData.to_tx !== delta.from_tx) {
+                    this.socketClient.emit('currencies');
+                    return false;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.currenciesData.data = jsondiffpatch.patch(this.currenciesData.data, deltaData);
+                this.currenciesData.to_tx = delta.to_tx;
+            });
+        });
+
+        // BALANCES
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('balance', (data) => {
+            _.forIn(data.data, (value) => {
+                const currency = _.filter(this.currenciesData.data, {
+                    name: value.currency,
+                })[0];
+                value.currency_kind = currency.kind;
+                value.currency_name = currency.name;
+                value.currency_big_name = currency.big_name;
+                value.currency_prefix = currency.prefix;
+                value.currency_postfix = currency.postfix;
+                value.currency_decimals = currency.decimals;
+            });
+            this.balancesData = data;
+            this.eventBus.emit('balance', null, this._deepClone(this.balancesData.data));
+        });
+
+        this.socketClient.on('balance-delta', (deltas) => {
+            _.forEach(deltas, (delta, index, collection) => {
+                if (this.balancesData.to_tx !== delta.from_tx) {
+                    this.socketClient.emit('balance');
+                    return false;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.balancesData.data = jsondiffpatch.patch(this.balancesData.data, deltaData);
+                this.balancesData.to_tx = delta.to_tx;
+                if (index === collection.length - 1) {
+                    _.forIn(this.balancesData.data, (value) => {
+                        const currency = _.filter(this.currenciesData.data, {
+                            name: value.currency,
+                        })[0];
+                        value.currency_kind = currency.kind;
+                        value.currency_name = currency.name;
+                        value.currency_big_name = currency.big_name;
+                        value.currency_prefix = currency.prefix;
+                        value.currency_postfix = currency.postfix;
+                        value.currency_decimals = currency.decimals;
+                    });
+
+                    this.eventBus.emit('balance', null, this._deepClone(this.balancesData.data));
+                }
+            });
+        });
+
+        // OPEN-ORDERS
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('open-orders', (data) => {
+            this.openOrdersData = data;
+            this.eventBus.emit('open-orders', null, this._deepClone(data.data));
+        });
+
+        this.socketClient.on('open-orders-delta', (deltas) => {
+            _.forEach(deltas, (delta, index, collection) => {
+                if (this.openOrdersData.to_tx !== delta.from_tx) {
+                    this.socketClient.emit('open-orders');
+                    return false;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.openOrdersData.data = jsondiffpatch.patch(this.openOrdersData.data, deltaData);
+                this.openOrdersData.to_tx = delta.to_tx;
+                if (index === collection.length - 1) {
+                    this.eventBus.emit('open-orders', null, this._deepClone(this.openOrdersData.data));
+                }
+            });
+        });
+
+        // HISTORICAL-ORDERS
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('historical-orders', (data) => {
+            this.historicalOrdersData = data;
+            this.eventBus.emit('historical-orders', null, this._deepClone(data.data));
+        });
+
+        this.socketClient.on('historical-orders-delta', (deltas) => {
+            _.forEach(deltas, (delta, index, collection) => {
+                if (this.historicalOrdersData.to_tx !== delta.from_tx) {
+                    this.socketClient.emit('historical-orders');
+                    return false;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.historicalOrdersData.data = jsondiffpatch.patch(
+                    this.historicalOrdersData.data,
+                    deltaData,
+                );
+                this.historicalOrdersData.to_tx = delta.to_tx;
+                if (index === collection.length - 1) {
+                    this.eventBus.emit('historical-orders', null, this._deepClone(this.historicalOrdersData.data));
+                }
+            });
+        });
+
+        // OPERATED
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('operated', (data) => {
+            this.operatedData = data;
+            this.eventBus.emit('operated', null, this._deepClone(this.operatedData.data));
+        });
+
+        this.socketClient.on('operated-delta', (deltas) => {
+            _.forEach(deltas, (delta, index, collection) => {
+                if (this.operatedData.to_tx !== delta.from_tx) {
+                    this.socketClient.emit('operated');
+                    return false;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.operatedData.data = jsondiffpatch.patch(this.operatedData.data, deltaData);
+                this.operatedData.to_tx = delta.to_tx;
+                if (index === collection.length - 1) {
+                    this.eventBus.emit('operated', null, this._deepClone(this.operatedData.data));
+                }
+            });
+        });
+
+        // OPEN-BOOK
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('open-book', (data) => {
+            this.openBookData[data.stock_id] = data;
+
+            const clean = {};
+            clean[data.stock_id] = {
+                sell: data.data[2],
+                buy: data.data[1],
+            };
+
+            this.eventBus.emit('open-book', null, this._deepClone(clean));
+        });
+
+        this.socketClient.on('open-book-delta', (delta) => {
+            const stockId = delta.stock_id;
+            if (_.has(this.openBookData, stockId)) {
+                if (this.openBookData[stockId].to_tx !== delta.from_tx) {
+                    this.socketClient.emit('open-book', {
+                        stockId,
+                    });
+                    return;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.openBookData[stockId].data = jsondiffpatch.patch(
+                    this.openBookData[stockId].data,
+                    deltaData,
+                );
+                this.openBookData[stockId].to_tx = delta.to_tx;
+
+                const clean = {};
+                clean[stockId] = {
+                    sell: this.openBookData[stockId].data[2],
+                    buy: this.openBookData[stockId].data[1],
+                };
+
+                this.eventBus.emit('open-book', null, this._deepClone(clean));
+            } else {
+                this.socketClient.emit('open-book', {
+                    stockId: delta.stock_id,
+                });
+            }
+        });
+
+        // HISTORICAL-BOOK
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('historical-book', (data) => {
+            const stockId = data.stock_id;
+
+            this.historicalBookData[stockId] = data;
+
+            const result = {};
+            result[stockId] = this.historicalBookData[stockId].data;
+
+            this.eventBus.emit('historical-book', null, this._deepClone(result));
+        });
+
+        this.socketClient.on('historical-book-delta', (delta) => {
+            const stockId = delta.stock_id;
+            if (_.has(this.historicalBookData, stockId)) {
+                if (this.historicalBookData[stockId].to_tx !== delta.from_tx) {
+                    this.socketClient.emit('historical-book', {
+                        stockId,
+                    });
+                    return;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.historicalBookData[stockId].data = jsondiffpatch.patch(
+                    this.historicalBookData[stockId].data,
+                    deltaData,
+                );
+                this.historicalBookData[stockId].to_tx = delta.to_tx;
+
+                const result = {};
+                result[stockId] = this.historicalBookData[stockId].data;
+
+                this.eventBus.emit('historical-book', null, this._deepClone(result));
+            } else {
+                this.socketClient.emit('historical-book', {
+                    stockId: delta.stock_id,
+                });
+            }
+        });
+
+        // CANDLES
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('candles', (data) => {
+            const stockId = data.stock_id;
+            this.candlesData[stockId] = data;
+
+            const result = {};
+            result[stockId] = this.candlesData[stockId].data;
+
+            const cloneResult = this._deepClone(result);
+
+            const cleanResult = _.mapValues(cloneResult, (obj) => {
+                if (_.has(obj, '1')) {
+                    obj.buy = obj['1'];
+                    delete obj['1'];
+                }
+
+                if (_.has(obj, '2')) {
+                    obj.sell = obj['2'];
+                    delete obj['2'];
+                }
+
+                return obj;
+            });
+
+            this.eventBus.emit('candles', null, cleanResult);
+        });
+
+        this.socketClient.on('candles-delta', (delta) => {
+            const stockId = delta.stock_id;
+            if (_.has(this.candlesData, stockId)) {
+                if (this.candlesData[stockId].to_tx !== delta.from_tx) {
+                    this.socketClient.emit('candles', {
+                        stockId,
+                    });
+                    return;
+                }
+
+                let deltaData = delta.delta_data;
+                if (_.isString(deltaData)) {
+                    deltaData = JSON.parse(deltaData);
+                }
+
+                this.candlesData[stockId].data = jsondiffpatch.patch(
+                    this.candlesData[stockId].data,
+                    deltaData,
+                );
+                this.candlesData[stockId].to_tx = delta.to_tx;
+
+                const result = {};
+                result[stockId] = this.candlesData[stockId].data;
+
+                const cloneResult = this._deepClone(result);
+
+                const cleanResult = _.mapValues(cloneResult, (obj) => {
+                    if (_.has(obj, '1')) {
+                        obj.buy = obj['1'];
+                        delete obj['1'];
+                    }
+
+                    if (_.has(obj, '2')) {
+                        obj.sell = obj['2'];
+                        delete obj['2'];
+                    }
+
+                    return obj;
+                });
+
+                this.eventBus.emit('candles', null, cleanResult);
+            } else {
+                this.socketClient.emit('candles', {
+                    stockId: delta.stock_id,
+                });
+            }
+        });
+
+        // BOARD
+        // ---------------------------------------------------------------------------------------------
+        this.socketClient.on('board', (data) => {
+            this.boardData = data;
+            this.eventBus.emit('ticker', null, this._deepClone(this.boardData.data));
+        });
+
+        this.socketClient.on('board-delta', (delta) => {
+            if (this.boardData.to_tx !== delta.from_tx) {
+                this.socketClient.emit('board');
+                return false;
+            }
+
+            let deltaData = delta.delta_data;
+            if (_.isString(deltaData)) {
+                deltaData = JSON.parse(deltaData);
+            }
+
+            this.boardData.data = jsondiffpatch.patch(this.boardData.data, deltaData);
+            this.boardData.to_tx = delta.to_tx;
+
+            this.eventBus.emit('ticker', null, this._deepClone(this.boardData.data));
+        });
+    }
+
+    connect(...transports) {
+        if (!_.isEmpty(transports)) {
+            this.transports = transports.filter(
+                (transport) => transport === 'polling' || transport === 'websocket',
+            );
+            if (_.isEmpty(this.transports)) {
+                return Promise.reject(new Error('Invalid transports'));
+            }
+        }
+        this.socketClient = socket(this.urlWorker, {
+            forceNew: false,
+            reconnectionAttempts: 1,
+            reconnectionDelay: 1000,
+            reconnectionDelayMax: 15000,
+            transports: this.transports,
+        });
+
+        this._setupGeneralEvents();
+        this._setupWorkerEvents();
+
+        return new Promise((resolve, reject) => {
+            // Fired upon a connection including a successful reconnection.
+            this.socketClient.on('connect', () => {
+                this._authSocket();
+                resolve(this);
+                this.eventBus.emit('connect');
+            });
+
+            // Fired upon a connection error.
+            this.socketClient.on('connect_error', (error) => {
+                reject(new Error(error));
+            });
+        });
+    }
+
+    on(event, callback) {
+        this.eventBus.on(event, callback);
+    }
+
+    subscribe(...pairs) {
+        _.forEach(pairs, (pair) => {
+            this.socketClient.emit('subscribe', pair);
+        });
+    }
+
+    unsubscribe(...pairs) {
+        _.forEach(pairs, (pair) => {
+            this.socketClient.emit('unsubscribe', pair);
+        });
+    }
 }
 
 module.exports = Socket;


### PR DESCRIPTION
Cuando se imprime en consola la instancia del SDK, se imprimen los api key/secret configurados, siendo inseguro sobre todo al haber excepciones. Para evitar esto se saca esas variables fuera de la clase, en el mismo scope pero sin exportar, por lo tanto no debería ser posible acceder a ellos desde fuera.

Además se agrega el método setCredentials para poder utilizar múltiples api keys según la request a usar.

También se envía los eventos connection y disconnection al cliente a través del eventBus para controlar la app cuando el socket se conecta/desconecta.